### PR TITLE
comments_controllerの設定、細かい修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -143,6 +144,12 @@ GEM
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     popper_js (1.16.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     public_suffix (4.0.3)
     puma (3.12.2)
     rack (2.2.2)
@@ -264,7 +271,6 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3.1)
-  byebug
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
@@ -272,6 +278,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  pry-byebug
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.1)
   refile!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  # before_action :set_team, if: :request.fullpath.include?(params[:team_id])
-  # before_action :set_issue, if: :request.fullpath.include?(params[:issue_id])
-  # before_action :set_user, if: :request.fullpath.include?(params[:user_id])
-  # before_action :set_comment, if: :request.fullpath.include?(params[:comment_id])
+  before_action :set_team
+  before_action :set_issue
+  before_action :set_user
+  before_action :set_comment
 
   private
   def configure_permitted_parameters
@@ -16,18 +16,27 @@ class ApplicationController < ActionController::Base
   end
 
   def set_team
-    @team = Team.find(params[:team_id])
+    if params[:team_id].present?
+      @team = Team.find(params[:team_id])
+    end
   end
 
   def set_issue
-    @issue = Issue.find(params[:issue_id])
+    if params[:issue_id].present?
+      @issue = Issue.find(params[:issue_id])
+    end
   end
 
   def set_user
-    @user = User.find(params[:user_id])
+    if params[:user_id].present?
+      @user = User.find(params[:user_id])
+    end
   end
 
   def set_comment
-    @comment = Comment.find(params[:comment_id])
+    if params[:comment_id].present?
+      @comment = Comment.find(params[:comment_id])
+    end
   end
+ 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,11 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  # before_action :set_team, if: :request.fullpath.include?(params[:team_id])
+  # before_action :set_issue, if: :request.fullpath.include?(params[:issue_id])
+  # before_action :set_user, if: :request.fullpath.include?(params[:user_id])
+  # before_action :set_comment, if: :request.fullpath.include?(params[:comment_id])
+
   private
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   before_action :set_issue
   before_action :set_user
   before_action :set_comment
+  # 条件分岐、path拾わなくてもパラメータ送られてるか否かで分岐すれば良くない？って結論に至る
 
   private
   def configure_permitted_parameters

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -15,6 +15,8 @@ class CommentsController < ApplicationController
       evaluation.difference = semi_difference / 3600
       # レスポンス評価を格納するだけ。ほんと汚い絶対メソッド化。
       # ストロングパラメータ効かない？
+      # view側からパラメータとして送られてないから。アクション内で全部やってるからrequireとpermitの組み合わせがうまいこといかん。
+      # メソッド化すればやりようあるので頑張れ
     end
     if comment.save(comment_params)
       evaluation.save

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,19 +8,20 @@ class CommentsController < ApplicationController
     if issue.comments.where(user_id: current_user).blank?
       evaluation = ResponseEvaluation.new
       evaluation.user = current_user
-      evaluation.issue = comment.issue
-      evaluation.created_issue_at = issue.created_at
+      evaluation.created_issue_at = comment.issue.created_at
       evaluation.first_comment_created_at = Time.current
       semi_difference = evaluation.first_comment_created_at - evaluation.created_issue_at
       evaluation.difference = semi_difference / 3600
+      evaluation.comment_id = comment.id
+      evaluation.save
       # レスポンス評価を格納するだけ。ほんと汚い絶対メソッド化。
       # ストロングパラメータ効かない？
       # view側からパラメータとして送られてないから。アクション内で全部やってるからrequireとpermitの組み合わせがうまいこといかん。
       # メソッド化すればやりようあるので頑張れ
     end
-    if comment.save(comment_params)
-      evaluation.save
-    else
+    binding.pry
+    unless comment.save(comment_params)
+      evaluation.destroy
       flash[:error] = "your comment had not save :("
     end
     redirect_back(fallback_location: root_path)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -27,11 +27,11 @@ class CommentsController < ApplicationController
   end
 
   def edit
-    @comment =  Comment.find(params[:id])
+    @comment =  Comment.find(params[:comment_id])
   end
 
   def update
-    comment = Comment.find(params[:id])
+    comment = Comment.find(params[:comment_id])
     if comment.update(comment_params)
       redirect_to team_issue_path(params[:team_id], params[:issue_id])
     else
@@ -41,7 +41,7 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    comment = Comment.find(params[:id])
+    comment = Comment.find(params[:comment_id])
     comment.destroy
     redirect_to team_issue_path(params[:team_id], params[:issue_id])
   end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -21,7 +21,7 @@ class IssuesController < ApplicationController
 
   def show
     @issue = Issue.find(params[:issue_id])
-    @comment = Comment.new
+    @new_comment = Comment.new
     @comments = @issue.comments
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,6 @@ class Comment < ApplicationRecord
   validates	:comment, presence: true
 
   belongs_to :user	
-	belongs_to :issue	
+  belongs_to :issue	
+  belongs_to :response_evaluations
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,5 +3,4 @@ class Comment < ApplicationRecord
 
   belongs_to :user	
   belongs_to :issue	
-  belongs_to :response_evaluations
 end

--- a/app/models/response_evaluation.rb
+++ b/app/models/response_evaluation.rb
@@ -1,4 +1,4 @@
 class ResponseEvaluation < ApplicationRecord
   belongs_to :user
-	belongs_to :issue
+	belongs_to :comment
 end

--- a/app/models/response_evaluation.rb
+++ b/app/models/response_evaluation.rb
@@ -1,4 +1,4 @@
 class ResponseEvaluation < ApplicationRecord
   belongs_to :user
-	belongs_to :comment
+	belongs_to :comment, optional: true
 end

--- a/app/views/layouts/_signin_header.html.erb
+++ b/app/views/layouts/_signin_header.html.erb
@@ -1,5 +1,5 @@
 <%= link_to "logout", destroy_user_session_path, method: :delete %>
 <%= link_to "join team", new_team_member_path %>
-<% unless request.fullpath.include? "mypage" || "team_member" %>
+<% unless request.fullpath.include? "mypage" %>
   <%= link_to "new issue", new_team_issue_path %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,8 @@ Rails.application.routes.draw do
   get 'mypage/:user_id/edit' => 'users#edit', as: "edit_user"
 
   # team_members
-  resources :team_members, only: [:new, :create]
+  resources :team_members, only: [:create]
+  get 'mypage/team_members/new' => 'team_members#new', as: "new_team_member"
 
   # teams
   resources :teams, only: [:show], param: :team_id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,9 +33,9 @@ Rails.application.routes.draw do
     resources :issues, only: [] do
       resources :comments, only: [:create, :edit, :update, :destroy], param: :comment_id
     end
-    get '/issues/:issue_id/choice' => 'issues#choice'
-    get '/issues/:issue_id/confirm' => 'issues#confirm'
-    put '/issues/:issue_id/settled' => 'issues#settled'
+    get '/issues/:issue_id/choice' => 'issues#choice', as: "choice"
+    get '/issues/:issue_id/confirm' => 'issues#confirm', as: "confirm"
+    put '/issues/:issue_id/settled' => 'issues#settled', as: "settled"
 
   end
 

--- a/db/migrate/20200219052114_create_response_evaluations.rb
+++ b/db/migrate/20200219052114_create_response_evaluations.rb
@@ -2,7 +2,7 @@ class CreateResponseEvaluations < ActiveRecord::Migration[5.2]
   def change
     create_table :response_evaluations do |t|
       t.integer :user_id, null: false
-      t.integer :comment_id, null: false
+      t.integer :comment_id
       t.datetime :created_issue_at, null: false
       t.datetime :first_comment_created_at, null: false
       t.float :difference, null: false

--- a/db/migrate/20200219052114_create_response_evaluations.rb
+++ b/db/migrate/20200219052114_create_response_evaluations.rb
@@ -2,13 +2,13 @@ class CreateResponseEvaluations < ActiveRecord::Migration[5.2]
   def change
     create_table :response_evaluations do |t|
       t.integer :user_id, null: false
-      t.integer :issue_id, null: false
+      t.integer :comment_id, null: false
       t.datetime :created_issue_at, null: false
       t.datetime :first_comment_created_at, null: false
       t.float :difference, null: false
 
       t.timestamps
     end
-    add_index :response_evaluations, [:user_id, :issue_id], unique: true
+    add_index :response_evaluations, [:user_id, :comment_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,13 +53,13 @@ ActiveRecord::Schema.define(version: 2020_02_19_052803) do
 
   create_table "response_evaluations", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.integer "issue_id", null: false
+    t.integer "comment_id", null: false
     t.datetime "created_issue_at", null: false
     t.datetime "first_comment_created_at", null: false
     t.float "difference", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id", "issue_id"], name: "index_response_evaluations_on_user_id_and_issue_id", unique: true
+    t.index ["user_id", "comment_id"], name: "index_response_evaluations_on_user_id_and_comment_id", unique: true
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 2020_02_19_052803) do
 
   create_table "response_evaluations", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.integer "comment_id", null: false
+    t.integer "comment_id"
     t.datetime "created_issue_at", null: false
     t.datetime "first_comment_created_at", null: false
     t.float "difference", null: false


### PR DESCRIPTION
・Comments_controller
→Response_evaluationを自動で作成、削除
→条件分岐はまだ調整中
・ルーティングの変数名変更
→にあわせてViewやControllerの変数名も変更
・Action_controllerに.findを共通メソッド化
→パラメータによって呼び出すタイミング分岐